### PR TITLE
Add Selector field (and OncePerCall) to handle polling APIs.

### DIFF
--- a/recorder.go
+++ b/recorder.go
@@ -47,6 +47,11 @@ const (
 	Passthrough
 )
 
+// Selector chooses a recorded Entry to response to a given request.
+type Selector interface {
+	Select(entries []Entry, req *http.Request) (Entry, bool)
+}
+
 // New is a convenience function for creating a new recorder.
 func New(filename string, filters ...Filter) *Recorder {
 	return &Recorder{
@@ -79,6 +84,12 @@ type Recorder struct {
 	// Transport to use for real request.
 	// If nil, http.DefaultTransport is used.
 	Transport http.RoundTripper
+
+	// An optional Select function may be specified to control which recorded
+	// Entry is selected to respond to a given request. If nil, the default
+	// selection is used that picks the first recorded response with a matching
+	// method and url.
+	Selector Selector
 
 	once    sync.Once
 	index   int
@@ -129,7 +140,13 @@ func (r *Recorder) RoundTrip(req *http.Request) (*http.Response, error) {
 	r.once.Do(r.loadFromDisk)
 
 	if r.Mode == Auto || r.Mode == ReplayOnly {
-		e, ok := r.Lookup(req.Method, req.URL.String())
+		var e Entry
+		var ok bool
+		if r.Selector != nil {
+			e, ok = r.Selector.Select(r.entries, req)
+		} else {
+			e, ok = r.Lookup(req.Method, req.URL.String())
+		}
 		if ok {
 			resp := e.Response
 			return &http.Response{


### PR DESCRIPTION
Previously, the implementation only picked the first matching recorded request.
In the case of a polling API, the tested function would never complete
because the polling would always return the first response and never the
completed response. Instead, this adds the Selector field that allows handling
this behavior.

Furthermore, exposing the Selector field allows users to implement custom
selection behavior easily but without complicating the recorder API: For
example, they could implement a Selector that repeats the final matched
response.
